### PR TITLE
FIX : Test if the FIRApp is already configured

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -95,7 +95,9 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
     }
 
     // [START configure_firebase]
-    [FIRApp configure];
+    if(![FIRApp defaultApp]) {
+        [FIRApp configure];
+    }
     // [END configure_firebase]
     // Add observer for InstanceID token refresh callback.
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tokenRefreshNotification:)


### PR DESCRIPTION
When using cordova-plugin-firebase-xxx, the app stop brutally because both of the plugins (FCM and Firebase) Configure the FIRApp .

Doing this test prevent the crash of the app.